### PR TITLE
bugfix in search_tag

### DIFF
--- a/streamlike/streamlike.py
+++ b/streamlike/streamlike.py
@@ -109,7 +109,7 @@ class Streamlike:
         return self.make_call('tag','POST',payload=payload)
 
     def search_tag(self, tag_id=None, params=None):
-        if media_id:
+        if tag_id:
             endpoint = 'tag/{0}'.format(tag_id)
         else:
             endpoint = 'tag'


### PR DESCRIPTION
Just a quick bugfix in Streamlike's `search_tag` method. 
The code was copied from `search_media` without catching that, I guess.

Cheers
